### PR TITLE
fix(vue3): typos and grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ But don't worry, you don't need a lot of experience to get started; just follow 
 
 ## How Can Pies Doc Help You?
 
-Pies Doc explains the fundamentals! Instead of digging into the source code and show you something extremely raw, this handbook emphasizes the part that relates to developers the most — the API itself.
+Pies Doc explains the fundamentals! Instead of digging into the source code and showing you something extremely raw, this handbook emphasizes the part that relates to developers the most — the API itself.
 
-By learning how to use API correctly and the theory behind it, you will not only be able to identify what is anti-pattern, but also significantly reduce the bugs and strange workarounds brought by inappropriate API usage.
+By learning how to use the API correctly and the theory behind it, you will not only be able to identify anti-patterns, but also significantly reduce the bugs and strange workarounds brought by inappropriate API usage.
 
-**Never underestimate the power of the fundamentals!** Although "to learn the fundamentals well" may not sound very cool and appealing, it is in fact an indispensable element for being able to comprehend more advanced knowledge.
+**Never underestimate the power of the fundamentals!** Although "learn the fundamentals well" may not sound very cool and appealing, it is in fact an indispensable element for being able to comprehend more advanced knowledge.
 
 ## Why Pies Doc?
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -15,11 +15,11 @@ But don't worry, you don't need a lot of experience to get started; just follow 
 
 ## How Can Pies Doc Help You?
 
-Pies Doc explains the fundamentals! Instead of digging into the source code and show you something extremely raw, this handbook emphasizes the part that relates to developers the most — the API itself.
+Pies Doc explains the fundamentals! Instead of digging into the source code and showing you something extremely raw, this handbook emphasizes the part that relates to developers the most — the API itself.
 
-By learning how to use API correctly and the theory behind it, you will not only be able to identify what is anti-pattern, but also significantly reduce the bugs and strange workarounds brought by inappropriate API usage.
+By learning how to use the API correctly and the theory behind it, you will not only be able to identify anti-patterns, but also significantly reduce the bugs and strange workarounds brought by inappropriate API usage.
 
-**Never underestimate the power of the fundamentals!** Although "to learn the fundamentals well" may not sound very cool and appealing, it is in fact an indispensable element for being able to comprehend more advanced knowledge.
+**Never underestimate the power of the fundamentals!** Although "learn the fundamentals well" may not sound very cool and appealing, it is in fact an indispensable element for being able to comprehend more advanced knowledge.
 
 ## Why Pies Doc?
 

--- a/docs/vue3/basic-syntax.md
+++ b/docs/vue3/basic-syntax.md
@@ -54,11 +54,11 @@ There's a new [`v-bind` in CSS](https://vuejs.org/api/sfc-css-features.html#v-bi
 
 ## `<script setup>`
 
-So what is this `<scrtip setup>`? What can the `setup` attribute do in a SFC?
+So what is this `<script setup>`? What can the `setup` attribute do in an SFC?
 
 Similar to the `export default { ... }` in Options API, the `setup` attribute on `<script>` is used to tell Vue that the code in this `<script>` block should be treated as the definition of a component. Anything we can do in Options API, we can also do it in `<script setup>`.
 
-Also, there **cannot be more than one `<script setup>`** in a SFC, just like how we cannot `export default` multiple times in a single file. You can have as many `<script>` as you want, just remember only one of them can be decorated with `setup` attribute.
+Also, there **cannot be more than one `<script setup>`** in an SFC, just like how we cannot `export default` multiple times in a single file. You can have as many `<script>` as you want, just remember only one of them can be decorated with `setup` attribute.
 
 ## Define a component
 

--- a/docs/vue3/composables.md
+++ b/docs/vue3/composables.md
@@ -20,7 +20,7 @@ You might be wondering what's the difference between a (util) function and a com
 
 :::caution
 
-Despite the fact that composables can be called from almost anywhere in a Vue app (because they're functions), it may not work if it's called before Vue instance is set up. For example, calling `onMounted()` before your Vue instance is set up is apparently not going to work.
+Despite the fact that composables can be called from almost anywhere in a Vue app (because they're functions), it may not work if it's called before Vue instance is set up. For example, calling `onMounted()` before your Vue instance is set up is not going to work.
 
 :::
 
@@ -72,7 +72,7 @@ export const useUserApi = () => {
 ```
 :::
 
-Since a lot of pages in the app are fetching data on mount, we would have to repeat the similar code again and again. Instead of doing that, we can make a composable and shove these code in it. For example:
+Since a lot of pages in the app fetch data on mount, we would have to repeat the similar code again and again. Instead of doing that, we can make a composable and shove the code in it. For example:
 
 ```ts title="UseFetchOnMount.ts" showLineNumbers
 import { ref, onMounted } from 'vue'
@@ -102,7 +102,7 @@ export const useFetchOnMount = <T>(url: string, initialValue: T) => {
   This is because React is using JSX, which means almost every piece of code in a component is being re-run on each re-render, but things are not the same in Vue. In a Vue component, `<script setup>` and `setup()` would only run once for each instance, so if we return `Ref<T>.value` instead of `Ref<T>` itself, we would lose the reactivity on these states.
 </details>
 
-The code in this composable is pretty much the same as the original code in the component; we're just moving it to a `.ts` file so that it's more reusable and testable. After we've done implementing it, we're now ready to use it in our components:
+The code in this composable is pretty much the same as the original code in the component; we're just moving it to a `.ts` file so that it's more reusable and testable. After we're done implementing it, we're now ready to use it in our components:
 
 ```html title="UsersPage.vue" showLineNumbers
 <template>
@@ -149,7 +149,7 @@ const [loadingProducts, products] = useFetchOnMount('/products', [])
 </script>
 ```
 
-With the help of composables, we're now able to reuse some functionalities that's shared across the whole app, thus reduce duplicate code.
+With the help of composables, we're now able to reuse some functionality that's shared across the whole app, thus reducing duplicate code.
 
 However, there are a few important things to keep in mind:
 

--- a/docs/vue3/define-a-component.md
+++ b/docs/vue3/define-a-component.md
@@ -8,8 +8,6 @@ import Badge from '@site/src/widgets/Badge'
 
 # Define a Component
 
-Learn a couple of ways to define a component in Vue 3.
-
 There are multiple ways to define a component in Vue 3, we want to bring up some commonly seen patterns you may use in your everyday life.
 
 ## 1. Legacy Options API
@@ -86,7 +84,7 @@ But don't get me wrong, Options API is still a great tool! It's still a valid wa
 
 This is the most popular option at the moment. If you've leaned React Hooks API, you may find the coding styles very similar. If you don't, don't worry! It's actually very easy to understand.
 
-By default there's no `this` in `<script setup>` whether you use function or arrow function. So if don't like `this`, this will be a good news!
+By default there's no `this` in `<script setup>` whether you use function or arrow function. So if don't like `this`, this will be good news!
 
 ```html title="Composition API with <script setup>" showLineNumbers
 <template>

--- a/docs/vue3/props.md
+++ b/docs/vue3/props.md
@@ -10,7 +10,7 @@ import Video from '@site/src/widgets/Video';
 
 ## What Are Props?
 
-Props are **properties coming from parent component**. These properties are stored in an object that, for most of the time, is being called `props`.
+Props are **properties coming from the parent component**. These properties are stored in an object that, for most of the time, is being called `props`.
 
 For example, if you declare your props in a component like this:
 
@@ -85,7 +85,7 @@ In this example:
 
 :::info
 
-Unlike `reactive()`, `shallowReactive()` does not go throught the [unwrap process](./unwrap-nested-ref) while making a proxy, so the return type of `shallowReactive()` is guaranteed to be the same as the type of arugment.
+Unlike `reactive()`, `shallowReactive()` does not go through the [unwrap process](./unwrap-nested-ref) while making a proxy, so the return type of `shallowReactive()` is guaranteed to be the same as the type of argument.
 
 :::
 
@@ -110,7 +110,7 @@ In this example, `user` is declared as a shallow readonly object, which means:
 - We cannot replace `user.child` with any other value.
 - We **can** mutate `user.child.age`.
 
-To sum up, you can think of `props` as a reactive proxy made by `shallowReactive()` and `shallowReadonly()`; it's just that all property values are coming from parent component.
+To sum it up, you can think of `props` as a reactive proxy made by `shallowReactive()` and `shallowReadonly()`; it's just that all property values are coming from parent component.
 
 ```ts showLineNumbers
 import { shallowReactive, shallowReadonly } from 'vue'
@@ -125,7 +125,7 @@ const props =
 
 :::info
 
-You should **always avoid directly mutating props in child components** so that the data flow of your components stays one-way (from top to bottom). If you have to mutate props in child components, you should use [`events`](https://vuejs.org/guide/components/events.html#component-events). The main concept is, parent component would be the only one that's allowed to mutate those values; all children do is to "trigger" those changes.
+You should **always avoid directly mutating props in child components** so that the data flow of your components stays one-way (from top to bottom). If you have to mutate props in child components, you should use [`events`](https://vuejs.org/guide/components/events.html#component-events). The main concept is, parent component is the only one that's allowed to mutate those values; all children do is to "trigger" those changes.
 
 :::
 

--- a/docs/vue3/reactive.md
+++ b/docs/vue3/reactive.md
@@ -18,7 +18,7 @@ This one line definition actually sums it up very well, but it might have brough
 - What is a **reactive proxy**?
 - What is **`UnwrapNestedRef<T>`**? (optional)
 
-We'll try to explain these stuff in this chapter. But before doing that, let's take a look at a simple example of `reactive()`:
+We'll try to explain these things in this chapter. But before doing that, let's take a look at a simple example of `reactive()`:
 
 ```ts showLineNumbers
 import { reactive } from 'vue'
@@ -75,7 +75,7 @@ Even if you declare it using `let count = reactive(0)`, your component will stil
 
 :::info
 
-- If you really need reactive primitive values, you should use [`ref()`](./ref-and-ref#what-is-ref).
+- If you need reactive primitive values, you should use [`ref()`](./ref-and-ref#what-is-ref).
 - We'll talk more about how `reactive()` works in [`ref()` or `reactive()`](./ref-or-reactive#how-reactive-works).
 
 :::
@@ -116,12 +116,12 @@ const getOld = () => {
 </script>
 ```
 
-The logic of this component is very simple — every time we click "Get Old", `user.age` will be incremeneted by 1.
+The logic of this component is very simple — every time we click "Get Old", `user.age` will be incremented by 1.
 In the very beginning, we see `hello is 5 years old` on the screen; no matter how many times the button is clicked, the number on the screen will always be `5`.
 
 <Video src="/video/reactive_non-reactive-value.mov" />
 
-This happens because `user` is not a reactive variable declared by using either `ref()` or `reactive()`. Since it's a non-reactive variable, our component just don't care about its' changes. Even though the value of `user.age` did get updated, the component still didn't re-render.
+This happens because `user` is not a reactive variable declared by using either `ref()` or `reactive()`. Since it's a non-reactive variable, our component just doesn't care about its changes. Even though the value of `user.age` did get updated, the component still didn't re-render.
 
 
 ### Reactive Proxy in `<template>`
@@ -154,7 +154,7 @@ const getOld = () => {
 </script>
 ```
 
-This component is almost the same as the previous one, the only difference is we're now declaring `user` with `reactive()`. Clicking the button for a couple of times, and you'll see the component finally gets re-rendered as how we've expected it to be.
+This component is almost the same as the previous one, the only difference is we're now declaring `user` with `reactive()`. Click the button a couple of times, and you'll see the component finally gets re-rendered as we expected it to be.
 
 <Video src="/video/reactive_reactive-proxy.mov" />
 
@@ -162,7 +162,7 @@ So why would using `reactive()` make such difference? This is because Vue is des
 
 ### Both Reactive and Non-reactive Values
 
-But be careful, that doens't mean the changes being made to non-reactive values will never be reflected on the screen. Let's take a look at the following example:
+But be careful, that doesn't mean the changes being made to non-reactive values will never be reflected on the screen. Let's take a look at the following example:
 
 ```html title="Both reactive and non-reactive values" showLineNumbers
 <template>
@@ -200,15 +200,15 @@ const getOld = () => {
 </script>
 ```
 
-In this example, we use both reactive and non-reactive values at the same time. The logic is simple — clicking "Change Name" will append an `o` to `cat.name`, and clicking "Get Old" will incremenet `dog.age` by 1.
+In this example, we use both reactive and non-reactive values at the same time. The logic is simple — clicking "Change Name" will append an `o` to `cat.name`, and clicking "Get Old" will increment `dog.age` by 1.
 
 Here we declare `cat` as a reactive proxy, and declare `dog` as a non-reactive object. We know that the changes being made to `cat` will cause the component to re-render because `cat` is a reactive proxy, while the changes being made to `dog` will not.
 
-At first we click "Change Name" for a couple of times, and each time we click it, the component re-renders with an `o` being appended to `hello`.
+At first we click "Change Name" a couple of times, and each time we click it, the component re-renders with an `o` being appended to `hello`.
 
 <Video src="/video/reactive_both-0.mov" />
 
-Then we click "Get Old" for a couple of times as well, this time the component does not re-render. That's exepcted because `dog` is neither a reactive proxy nor a `Ref<T>`.
+Then we click "Get Old" a couple of times as well, this time the component does not re-render. That's expected because `dog` is neither a reactive proxy nor a `Ref<T>`.
 
 <Video src="/video/reactive_both-1.mov" />
 
@@ -252,7 +252,7 @@ child.name = 'world'
 console.log(user.child.name, child.name) // 'world', 'world'
 ```
 
-The above example demonstrates a common misconception that everything we get from reactive proxy is always "connected" to the source, but it's acutally not! For example:
+The above example demonstrates a common misconception that everything we get from reactive proxy is always "connected" to the source, but it's actually not! For example:
 
 ```ts showLineNumbers
 import { reactive } from 'vue'
@@ -297,7 +297,7 @@ As you can see, the changes we made to `user` did not effect `myName` and `myAge
 
 Why is it that in the first example, mutating `child.name` did effect `user.child`, while the same behavior cannot be observed in the second example?
 
-_Is it a problem by using destructing assignment with `reactive()`?_
+_Is it a problem to use a destructing assignment with `reactive()`?_
 
 Not really. The same thing would happen even if we use `const myName = user.name` (because that's exactly what destructing assignment does), so it's not quite correct to say destructing assignment causes the problem.
 

--- a/docs/vue3/ref-and-ref.md
+++ b/docs/vue3/ref-and-ref.md
@@ -27,7 +27,7 @@ interface Ref<T> {
 }
 ```
 
-A `Ref<T>` contain only **one** value of any type, so you can have:
+A `Ref<T>` contains only **one** value of any type, so you can have:
 
 - `Ref<number>`
 - `Ref<number[]>`
@@ -114,7 +114,7 @@ const name = ref('hello')
 
 Because `name` is a `Ref<T>`, it is very reasonable to think that `<div>{{ name.value }}</div>` will evaluate to `<div>hello</div>`. But when this component gets rendered, the output HTML will actually be `<div></div>`, without `hello` in the middle — where's our `hello`?
 
-In Vue 3, when we try to access `Ref<T>` from `<template>`, **sometimes** (yes, SOMETIMES!) they will be automatically unwrapped. To **unwrap** (or [**unref**](https://vuejs.org/api/reactivity-utilities.html#unref)) means to take the `value` out from `Ref<T>`. Hence, we must omit the `.value` behind a `Ref<T>` in `<template>` under some circumstances because Vue auto-unwrap them sometimes. So what are these "circumstances"?
+In Vue 3, when we try to access `Ref<T>` from `<template>`, **sometimes** (yes, SOMETIMES!) they will be automatically unwrapped. To **unwrap** (or [**unref**](https://vuejs.org/api/reactivity-utilities.html#unref)) means to take the `value` out from `Ref<T>`. Hence, we must omit the `.value` behind a `Ref<T>` in `<template>` under some circumstances because Vue auto-unwraps them sometimes. So what are these "circumstances"?
 
 The rule is simple: Vue will only auto-unwrap a `Ref<T>` in `<template>` if it is exposed as a **top-level property** in `<script setup>`. This rule also applies to v-on and v-bind.
 
@@ -183,7 +183,7 @@ Do you know why there's such difference?
 
 </details>
 
-Great, now you know how `Ref<T>` works in `<template>`! This is especially important when using [composables](./composables). Without knowing this, you will end up writing so many `.value` in `<template>` that could have been avoided, which decreases the readibility of your code.
+Great, now you know how `Ref<T>` works in `<template>`! This is especially important when using [composables](./composables). Without knowing this, you will end up writing so many `.value` in `<template>` that could have been avoided, which decreases the readability of your code.
 
 ## `ComputedRef<T>` Is Also `Ref<T>`
 

--- a/docs/vue3/ref-or-reactive.md
+++ b/docs/vue3/ref-or-reactive.md
@@ -32,7 +32,7 @@ In order to know how to choose between `ref()` and `reactive()`, it's essential 
 The following pseudocode gives us a decent concept of how `ref()` works in Vue 3. Although it is extremely simplified and rearranged, we're still able to get the main idea of what's going on inside `ref()`:
 
 ```ts showLineNumbers
-import { reactvie, Ref } from 'vue'
+import { reactive, Ref } from 'vue'
 
 const ref = (arg) => {
   if (arg is Ref) {
@@ -137,8 +137,8 @@ If you REALLY want a function to be reactive (which we cannot think of any good 
 
 ### Any Other Type
 
-Anything other than primitive value and function falls into this category. For example, plain object, Array, Map, etc.
+Anything other than primitive values and functions fall into this category. For example, plain object, Array, Map, etc.
 
-In these cases, it doesn't really matter if you use `ref()` or `reactive()`, because under these circumstances, `reactive()` will be the one to generate the final value. The `.value` after `Ref<T>` would be the only difference.
+In these cases, it doesn't really matter if you use `ref()` or `reactive()`, because under these circumstances, `reactive()` will be the one to generate the final value. The `.value` after `Ref<T>` is the only difference.
 
-Since none is better than the other, using either `ref()` or `reactive()` is fine. Just make sure **the whole team/project is following the same rule when choosing `ref()` and `reactive()`** for code consistency and you'll be just fine!
+Since neither is better than the other, using either `ref()` or `reactive()` is fine. Just make sure **the whole team/project is following the same rule when choosing `ref()` and `reactive()`** for code consistency and you'll be just fine!

--- a/docs/vue3/unwrap-nested-ref.md
+++ b/docs/vue3/unwrap-nested-ref.md
@@ -112,7 +112,7 @@ const unwrapRef = <T>(arg: T): UnwrapRef<T> => {
 }
 ```
 
-The above pseudocode just sums everything up! Take your time to read and understand the pseudocode, hopefully it will give you a decent understanding of how the unwrap mechanism works in `reactive()`!
+The above pseudocode sums everything up! Take your time to read and understand the pseudocode, hopefully it will give you a decent understanding of how the unwrap mechanism works in `reactive()`!
 
 Below here we'll just highlight some commonly seen scenarios, and things you should pay attention to.
 
@@ -122,7 +122,7 @@ Below here we'll just highlight some commonly seen scenarios, and things you sho
 
 ## Partial Reactive Object
 
-When using Vue 3, you should try to **avoid declaring partial reactive object** because usually the are the source of bugs. For example:
+When using Vue 3, you should try to **avoid declaring partial reactive object** because usually they are a source of bugs. For example:
 
 
 ```ts showLineNumbers
@@ -138,4 +138,4 @@ const user = {
 }
 ```
 
-In this example, mutating any property inside `user.friend.child` will cause the component to re-render, while mutating any other property will not. In this case, using `ref()` would be slight better than using `reactive()` because by seeing `.value`, you'll know that it's probably a `Ref<T>` (but not guaranteed). Still, it's recommended to avoid such pattern because it's difficult to understand.
+In this example, mutating any property inside `user.friend.child` will cause the component to re-render, while mutating any other property will not. In this case, using `ref()` would be slight better than using `reactive()` because by seeing `.value`, you'll know that it's probably a `Ref<T>` (but not guaranteed). Still, it's recommended to avoid this pattern because it's difficult to understand.

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/vue3/basic-syntax.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/vue3/basic-syntax.md
@@ -54,7 +54,7 @@ Vue 3 有个 [在 CSS 里面使用 `v-bind`](https://vuejs.org/api/sfc-css-featu
 
 ## `<script setup>`
 
-什么是 `<scrtip setup>`？ 这个 `setup` 属性又有什么用处？
+什么是 `<script setup>`？ 这个 `setup` 属性又有什么用处？
 
 和选项式 API (Options API) 中的 `export default { ... }` 相似，`<script>` 中的 `setup` 属性是用来告诉 Vue 这个 `<script>` 区块里面的代码代表这个组件的定义。所有我们在选项式 API 里面能做到的事情，在 `<script setup>` 里面也都能做到。
 

--- a/i18n/zh-Hans/docusaurus-plugin-content-docs/current/vue3/ref-or-reactive.md
+++ b/i18n/zh-Hans/docusaurus-plugin-content-docs/current/vue3/ref-or-reactive.md
@@ -32,7 +32,7 @@ keywords: [派氏文件, vue3, vue ref, vue reactive, vue ref和reactive]
 下面的伪代码 (pseudocode) 能大概让我们知道 `ref()` 在 Vue 3 中是如何运作的。虽然这个伪代码经过极度的化简和改写，我们还是能一窥 `ref()` 的运作原理：
 
 ```ts showLineNumbers
-import { reactvie, Ref } from 'vue'
+import { reactive, Ref } from 'vue'
 
 const ref = (arg) => {
   if (arg is Ref) {

--- a/i18n/zh-Hant/docusaurus-plugin-content-docs/current/vue3/basic-syntax.md
+++ b/i18n/zh-Hant/docusaurus-plugin-content-docs/current/vue3/basic-syntax.md
@@ -54,7 +54,7 @@ Vue 3 有個 [在 CSS 裡面使用 `v-bind`](https://vuejs.org/api/sfc-css-featu
 
 ## `<script setup>`
 
-什麼是 `<scrtip setup>`？ 這個 `setup` 屬性又有什麼用處？
+什麼是 `<script setup>`？ 這個 `setup` 屬性又有什麼用處？
 
 和選項式 API (Options API) 中的 `export default { ... }` 相似，`<script>` 中的 `setup` 屬性是用來告訴 Vue 這個 `<script>` 區塊裡面的程式碼代表這個元件的定義。所有我們在選項式 API 裡面能做到的事情，在 `<script setup>` 裡面也都能做到。
 

--- a/i18n/zh-Hant/docusaurus-plugin-content-docs/current/vue3/ref-or-reactive.md
+++ b/i18n/zh-Hant/docusaurus-plugin-content-docs/current/vue3/ref-or-reactive.md
@@ -32,7 +32,7 @@ keywords: [派氏文件, vue3, vue ref, vue reactive, vue ref和reactive]
 下面的虛擬碼 (pseudocode) 能大概讓我們知道 `ref()` 在 Vue 3 中是如何運作的。雖然這個虛擬碼經過極度的化簡和改寫，我們還是能一窺 `ref()` 的運作原理：
 
 ```ts showLineNumbers
-import { reactvie, Ref } from 'vue'
+import { reactive, Ref } from 'vue'
 
 const ref = (arg) => {
   if (arg is Ref) {

--- a/src/components/home/HomeFeatures.tsx
+++ b/src/components/home/HomeFeatures.tsx
@@ -58,18 +58,18 @@ export default function HomeFeatures() {
             translate({
               id: 'home.features.how_text_0',
               message: `Pies Doc explains the fundamentals! Instead of digging into the source code
-              and show you something extremely raw, this handbook emphasizes the part that relates to
+              and showing you something extremely raw, this handbook emphasizes the part that relates to
               developers the most — the API itself.`,
             }),
             translate({
               id: 'home.features.how_text_1',
-              message: `By learning how to use API correctly and the theory behind it, you
-              will not only be able to identify what is anti-pattern, but also significantly
+              message: `By learning how to use the API correctly and the theory behind it, you
+              will not only be able to identify anti-patterns, but also significantly
               reduce the bugs and strange workarounds brought by inappropriate API usage.`,
             }),
             translate({
               id: 'home.features.how_text_2',
-              message: `Never underestimate the power of the fundamentals! Although "to learn the
+              message: `Never underestimate the power of the fundamentals! Although "learn the
               fundamentals well" may not sound very cool and appealing, it is in fact an
               indispensable element for being able to comprehend more advanced
               knowledge.`,


### PR DESCRIPTION
Nice documentation! It looks clean.

While reading through, I made a few grammar/typo fixes here and there. I tried to avoid changes related to my opinions on writing style, but let me know if you prefer anything to be reverted 😅 